### PR TITLE
Release 1.9.1

### DIFF
--- a/com.github.AlizaMedicalImaging.AlizaMS.yaml
+++ b/com.github.AlizaMedicalImaging.AlizaMS.yaml
@@ -1,7 +1,7 @@
 app-id: com.github.AlizaMedicalImaging.AlizaMS
 runtime: org.kde.Platform
 sdk: org.kde.Sdk
-runtime-version: 5.15-21.08
+runtime-version: 6.4
 command: alizams
 rename-desktop-file: alizams.desktop
 rename-appdata-file: alizams.metainfo.xml
@@ -51,13 +51,12 @@ modules:
     buildsystem: cmake-ninja
     config-opts:
       - -DCMAKE_BUILD_TYPE:STRING=RelWithDebInfo
-      - -DALIZA_QT_VERSION:STRING=5
-      - -DALIZA_QT5_COREGL:BOOL=ON
+      - -DALIZA_QT_VERSION:STRING=6
       - -DMDCM_USE_SYSTEM_ZLIB:BOOL=ON
     post-install:
       - desktop-file-edit --set-icon $FLATPAK_ID --set-key Exec --set-value 'alizams' /app/share/applications/alizams.desktop
       - appstream-util modify /app/share/metainfo/alizams.metainfo.xml id com.github.AlizaMedicalImaging.AlizaMS
     sources:
       - type: archive
-        url: https://github.com/AlizaMedicalImaging/AlizaMS/archive/v1.9.0/AlizaMS-1.9.0.tar.gz
-        sha256: 3a4d78b4520390461062e8994f123e8144492683557a0039b5d88343f40e3f0a
+        url: https://github.com/AlizaMedicalImaging/AlizaMS/archive/v1.9.1/AlizaMS-1.9.1.tar.gz
+        sha256: b0b6dfbf050b0968cda3cbeddd1a17d8db2629deee69fc8eaa415bfeb516e767


### PR DESCRIPTION
Bug-fix release.
 
 - Fixed issue with the Wayland platform (optional)
 - Fixed minor bug with Siemens Mosaic files
 - Improved support for the VNC platform
 - Set OpenGL Core Profile to be default
 - Better workaround missing required OpenGL version