### PR TITLE
Release 1.9.8

### DIFF
--- a/com.github.AlizaMedicalImaging.AlizaMS.yaml
+++ b/com.github.AlizaMedicalImaging.AlizaMS.yaml
@@ -59,8 +59,9 @@ modules:
       - -DMDCM_USE_SYSTEM_ZLIB:BOOL=ON
     post-install:
       - desktop-file-edit --set-icon $FLATPAK_ID --set-key Exec --set-value 'alizams' /app/share/applications/alizams.desktop
-      - appstream-util modify /app/share/metainfo/alizams.metainfo.xml id com.github.AlizaMedicalImaging.AlizaMS
     sources:
       - type: archive
-        url: https://github.com/AlizaMedicalImaging/AlizaMS/archive/v1.9.7/AlizaMS-1.9.7.tar.gz
-        sha256: 1e95c8029d9303ee7635c35500c28fc6c1f3dd8b04a6721cee8dcfda5e99e27a
+        url: https://github.com/AlizaMedicalImaging/AlizaMS/archive/v1.9.8/AlizaMS-1.9.8.tar.gz
+        sha256: 50a4a262bd8ec2f5aaf98bd332062d13fbecd7ef55f063dccd2fc2ea3f7e73fd
+      - type: patch
+        path: fix-metainfo-id.patch

--- a/fix-metainfo-id.patch
+++ b/fix-metainfo-id.patch
@@ -1,0 +1,33 @@
+diff --git a/package/archive/usr/share/metainfo/alizams.metainfo.xml b/package/archive/usr/share/metainfo/alizams.metainfo.xml
+index f5f66be..cd55ee8 100644
+--- a/package/archive/usr/share/metainfo/alizams.metainfo.xml
++++ b/package/archive/usr/share/metainfo/alizams.metainfo.xml
+@@ -1,7 +1,11 @@
+ <?xml version="1.0" encoding="UTF-8"?>
+ <component type="desktop-application">
+-  <id>alizams.desktop</id>
++  <id>com.github.AlizaMedicalImaging.AlizaMS</id>
++  <launchable type="desktop-id">com.github.AlizaMedicalImaging.AlizaMS.desktop</launchable>
+   <name>Aliza MS</name>
++  <developer id="com.github.AlizaMedicalImaging">
++    <name>Aliza Medical Imaging Team</name>
++  </developer>
+   <summary>A DICOM viewer</summary>
+   <metadata_license>FSFAP</metadata_license>
+   <project_license>GPL-3.0-only</project_license>
+@@ -56,12 +60,15 @@
+   </content_rating>
+   <screenshots>
+     <screenshot type="default">
++      <caption>Main window</caption>
+       <image>https://raw.githubusercontent.com/AlizaMedicalImaging/AlizaMS/v1.9.8/package/art/alizams_scr1.jpg</image>
+     </screenshot>
+     <screenshot>
++      <caption>Multi-view</caption>
+       <image>https://raw.githubusercontent.com/AlizaMedicalImaging/AlizaMS/v1.9.8/package/art/alizams_scr2.jpg</image>
+     </screenshot>
+     <screenshot>
++      <caption>Metadata viewer</caption>
+       <image>https://raw.githubusercontent.com/AlizaMedicalImaging/AlizaMS/v1.9.8/package/art/alizams_scr3.jpg</image>
+     </screenshot>
+   </screenshots>


### PR DESCRIPTION
also uses 'patch' instead 'appstream-util modify', s. https://github.com/flathub/com.github.AlizaMedicalImaging.AlizaMS/issues/16

Closes #16